### PR TITLE
Allow definition of CPU architecture.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Features:
 * `log_group_region` - The region where the log group exists. By default the current region will be used.
 * `task_cpu` - How much CPU should be reserved for the container (in aws cpu-units). Default is `256`.
 * `task_memory` - How much Memory should be reserved for the container (in MB). Default is `512`.
+* `task_cpu_architecture` - The task CPU architecture (e.g. `X86_64`, `ARM64`); Only supported on platform version `1.4.0`. Default is `X86_64`.
 * `container_port` - Port the container listens on. Default is `80` (only valid with single container configurations, if using more then one container the port will need to be defined with your container definitions).
 * `platform_version` - The ECS backend platform version; Defaults to `1.4.0` so EFS is supported.
 * `task_policy_json` - A JSON formatted IAM policy providing the running container with permissions.  By default, no permissions granted.

--- a/fargate-task.tf
+++ b/fargate-task.tf
@@ -62,6 +62,10 @@ resource "aws_ecs_task_definition" "fargate" {
   requires_compatibilities = ["FARGATE"]
   tags                     = merge(var.tags, var.tags_ecs, var.tags_ecs_task_definition)
 
+  runtime_platform {
+    cpu_architecture = var.task_cpu_architecture
+  }
+
   dynamic "volume" {
     iterator = volume
     for_each = local.efs_volumes

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,11 @@ variable "task_memory" {
   description = "Optional; A fargate compliant container memory value."
   default     = 512
 }
+variable "task_cpu_architecture" {
+  type        = string
+  description = "Optional; The task CPU architecture; Defaults to X86_64."
+  default     = "X86_64"
+}
 variable "platform_version" {
   type        = string
   description = "Optional; The ECS backend platform version; Defaults to 1.4.0 so EFS is supported."

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.47, < 4.0.0"
+      version = ">= 3.69, < 4.0.0"
     }
   }
 }


### PR DESCRIPTION
The option to use Graviton CPUs was recently announced and the feature was adopted shortly after by Terraform.

See:

https://aws.amazon.com/de/blogs/aws/announcing-aws-graviton2-support-for-aws-fargate-get-up-to-40-better-price-performance-for-your-serverless-containers/

and

https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#3690-december-09-2021
