### PR TITLE
Adding IAM Role permission boundary and path variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
-## Unreleased
-
+## v8.1.0
 * **NEW FEATURE**
   * Adds `iam_role_path` and `iam_role_permissions_boundary` for additional IAM role configuration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+* **NEW FEATURE**
+  * Adds `iam_role_path` and `iam_role_permissions_boundary` for additional IAM role configuration
+
 ## v8.0.0
 * **UPDATE**
   * Updated aws provider version from `>= 3.69, < 4.0` to `~> 4.0`

--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ Features:
 * `container_port` - Port the container listens on. Default is `80` (only valid with single container configurations, if using more then one container the port will need to be defined with your container definitions).
 * `platform_version` - The ECS backend platform version; Defaults to `1.4.0` so EFS is supported.
 * `task_policy_json` - A JSON formatted IAM policy providing the running container with permissions.  By default, no permissions granted.
+* `iam_role_path` - Path attached to created IAM roles
+* `iam_role_permissions_boundary` - Permissions Boundary ARN attached to created IAM roles
 
-##### Container volume ocnfiguration
+##### Container volume configuration
 * `efs_configs` - List of {file_system_id, root_directory, container_path, container_name} EFS mounts.
 * `nonpersistent_volume_configs` - List of {volume_name, container_name, container_path} non-persistent volumes
 

--- a/fargate-execution-role.tf
+++ b/fargate-execution-role.tf
@@ -45,6 +45,9 @@ resource "aws_iam_role" "ecs_execution" {
   name               = "${var.family}-exec-basic"
   assume_role_policy = data.aws_iam_policy_document.ecs_execution_principal.json
   tags               = merge(var.tags, var.tags_iam_role)
+
+  path                 = var.iam_role_path
+  permissions_boundary = var.iam_role_permissions_boundary
 }
 resource "aws_iam_role_policy" "ecs_execution" {
   name   = "${var.family}-exec-basic"

--- a/fargate-task-role.tf
+++ b/fargate-task-role.tf
@@ -12,6 +12,9 @@ resource "aws_iam_role" "ecs_task" {
   name               = "${var.family}-task"
   assume_role_policy = data.aws_iam_policy_document.ecs_task_principal.json
   tags               = merge(var.tags, var.tags_iam_role)
+
+  path                 = var.iam_role_path
+  permissions_boundary = var.iam_role_permissions_boundary
 }
 resource "aws_iam_role_policy" "ecs_task" {
   count  = var.task_policy_json != "" ? 1 : 0

--- a/variables.tf
+++ b/variables.tf
@@ -409,12 +409,12 @@ variable "tags_iam_role" {
   default     = {}
 }
 variable "iam_role_path" {
-  description = "Path attached to created iam roles"
+  description = "Optional; Path attached to created IAM roles"
   type        = string
   default     = null
 }
 variable "iam_role_permissions_boundary" {
-  description = "Permissions Boundary ARN attached to created IAM roles"
+  description = "Optional; Permissions Boundary ARN attached to created IAM roles"
   type        = string
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -408,3 +408,13 @@ variable "tags_iam_role" {
   description = "Optional; Map of key-value tags to apply to IAM Roles"
   default     = {}
 }
+variable "iam_role_path" {
+  description = "Path attached to created iam roles"
+  type        = string
+  default     = null
+}
+variable "iam_role_permissions_boundary" {
+  description = "Permissions Boundary ARN attached to created IAM roles"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
Some developers are using roles that require IAM Role Permissions Boundaries and Paths.  Default value is null (as it stands today) so this should be a minor version bump.

Here are some examples of this pattern/requirement from terraform-aws-modules:
* [rds-proxy](https://github.com/terraform-aws-modules/terraform-aws-rds-proxy/blob/master/variables.tf#L217-L221)
* [rds-aurora](https://github.com/terraform-aws-modules/terraform-aws-rds-aurora/blob/dda5fcd8d984cc802b9dab05193d36ec41f25820/main.tf#L237)