### PR TITLE
feat: Adding alb_drop_invalid_header_fields flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v9.2.0
+* **NEW FEATURE**
+  * Adds `alb_drop_invalid_header_fields` to allow enabling this security feature of the ALB
+
 ## v9.1.0
 * **NEW FEATURE**
   * Adds `iam_role_path` and `iam_role_permissions_boundary` for additional IAM role configuration

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Features:
 * `ipv6` - Boolean to enable ipv6 on the ALB and Route53.  Ensure your VPC is configured to be ipv6 compatible before enabling.  Defaults to `false`.
 * `alb_sticky_duration` - Optional; Enables ALB sticky sessions and sets the time to the value; default is disabled
 * `alb_sticky_cookie_name` - Optional; Sets the ALB sticky type to app_cookie and the cookie name to the value; default is empty, which sets sticky type to lb_cookie
+* `alb_drop_invalid_header_fields` - Optional; Indicates whether HTTP headers with header fields that are not valid are removed by the load balancer (true) or routed to targets (false). The default is false. Elastic Load Balancing requires that message header names contain only alphanumeric characters and hyphens. Only valid for Load Balancers of type application.
 
 ##### Lights On/Off
 

--- a/alb.tf
+++ b/alb.tf
@@ -5,7 +5,9 @@ resource "aws_lb" "alb" {
   security_groups    = concat(var.alb_security_group_ids, [aws_security_group.alb_ingress.id])
   subnets            = local.public_subnet_ids_provided ? var.public_subnet_ids : local.private_subnet_ids_provided ? var.private_subnet_ids : data.aws_subnets.default[0].ids
   ip_address_type    = var.ipv6 ? "dualstack" : "ipv4"
-  idle_timeout       = var.alb_idle_timeout
+
+  idle_timeout               = var.alb_idle_timeout
+  drop_invalid_header_fields = var.alb_drop_invalid_header_fields
 
   dynamic "access_logs" {
     for_each = var.alb_log_bucket_name != "" ? ["enabled"] : []

--- a/examples/alb-security-group/main.tf
+++ b/examples/alb-security-group/main.tf
@@ -62,9 +62,10 @@ module "easy_fargate_alb_sg" {
   tags = {
     ManagedBy = "Terraform"
   }
-  alb_security_group_ids = [aws_security_group.alb_sg.id]
-  alb_idle_timeout       = 300
-  wait_for_steady_state  = true
+  alb_security_group_ids         = [aws_security_group.alb_sg.id]
+  alb_idle_timeout               = 300
+  alb_drop_invalid_header_fields = true
+  wait_for_steady_state          = true
 }
 output "dev_connection_information" {
   value = <<-EOT

--- a/variables.tf
+++ b/variables.tf
@@ -70,6 +70,11 @@ variable "alb_sticky_cookie_name" {
   description = "Optional; Sets the ALB sticky type to app_cookie and the cookie name to the value; default is empty, which sets sticky type to lb_cookie"
   default     = ""
 }
+variable "alb_drop_invalid_header_fields" {
+  type        = bool
+  description = "Optional; Indicates whether HTTP headers with header fields that are not valid are removed by the load balancer (true) or routed to targets (false). The default is false. Elastic Load Balancing requires that message header names contain only alphanumeric characters and hyphens. Only valid for Load Balancers of type application."
+  default     = false
+}
 
 # Application Load Balancer Health Checks
 variable "health_check_path" {


### PR DESCRIPTION
Implementing the ability to use this aws_lb property: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb#drop_invalid_header_fields