### PR TITLE
IA-5451: Add support for custom IAM statement on task-exec policy.

### DIFF
--- a/fargate-execution-role.tf
+++ b/fargate-execution-role.tf
@@ -40,6 +40,16 @@ data "aws_iam_policy_document" "ecs_execution" {
       resources = local.extracted_container_secrets.*.valueFrom
     }
   }
+  # Custom policy statement for additional application-specific resources, e.g. KMS
+  dynamic "statement" {
+    count = var.exec_role_extra_permissions ? ["enabled"] : []
+    content {
+      sid    = "AdditionalAppServices"
+      effect = "Allow"
+      actions = var.exec_role_extra_permissions 
+      resources = var.exec_role_extra_arns 
+    }
+  }
 }
 resource "aws_iam_role" "ecs_execution" {
   name               = "${var.family}-exec-basic"

--- a/variables.tf
+++ b/variables.tf
@@ -337,6 +337,18 @@ variable "iam_role_permissions_boundary" {
   default     = null
 }
 
+variable "var.exec_role_extra_permissions" {
+  type        = list(string)
+  description = "Optional; List of additional permissions to grant ECS task execution role. Used to access additional services required by the application."
+  default     = []
+}
+
+variable "var.exec_role_extra_arns" {
+  type        = list(string)
+  description = "Optional; Restrict additional IAM permissions for ECS execution role to acting on this List of ARNs."
+  default     = []
+}
+
 # WAF and Shield
 variable "enable_shield_protection" {
   type        = bool


### PR DESCRIPTION
This adds the ability add custom permissions to the IAM role for ECS task execution. It consists of two variables and a dynamic block which appends an additional statement to the task execution role's policy.

* The user may add a list of service permissions in `exec_role_extra_permissions`.
* The user may add a list of desired ARNs to be permitted `Resources` for their specified policy actions.

This was successfully tested several times while redeploying the DKAN service for testing. During local deployments, I changed the module `source` to my local path for this working branch.